### PR TITLE
Feature: Allows to force a colorScheme

### DIFF
--- a/Sources/Neumorphic/ColorExtension.swift
+++ b/Sources/Neumorphic/ColorExtension.swift
@@ -24,9 +24,23 @@ public extension Color {
         
         private static func color(light: ColorType, dark: ColorType) -> Color {
             #if os(iOS)
-            return Color(.init { $0.userInterfaceStyle == .light ? light : dark })
+            switch neumorphicColorScheme {
+            case .light:
+                return Color(light)
+            case .dark:
+                return Color(dark)
+            case .auto:
+                return Color(.init { $0.userInterfaceStyle == .light ? light : dark })
+            }
             #else
-            return isDarkMode() ? dark : light
+            switch neumorphicColorScheme {
+            case .light:
+                return light
+            case .dark:
+                return dark
+            case .auto:
+                return isDarkMode() ? dark : light
+            }
             #endif
         }
         

--- a/Sources/Neumorphic/ColorExtension.swift
+++ b/Sources/Neumorphic/ColorExtension.swift
@@ -3,72 +3,44 @@ import SwiftUI
 public extension Color {
 
     struct Neumorphic {
-        #if os(macOS)
-        private typealias ColorType = Color
-        private static func colorType(red: Double, green: Double, blue: Double) -> ColorType {
-            .init(red: red, green: green, blue: blue, opacity: 1.0)
-        }
-        
-        private static func isDarkMode() -> Bool {
-            if let window = NSApp.mainWindow {
-                return window.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-            }
-            return NSAppearance.current.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-        }
-        #else
-        private typealias ColorType = UIColor
-        private static func colorType(red: CGFloat, green: CGFloat, blue: CGFloat) -> ColorType {
-            .init(red: red, green: green, blue: blue, alpha: 1.0)
-        }
-        #endif
-        
-        private static func color(light: ColorType, dark: ColorType) -> Color {
-            #if os(iOS)
-            switch neumorphicColorScheme {
-            case .light:
-                return Color(light)
-            case .dark:
-                return Color(dark)
-            case .auto:
-                return Color(.init { $0.userInterfaceStyle == .light ? light : dark })
-            }
-            #else
-            switch neumorphicColorScheme {
-            case .light:
-                return light
-            case .dark:
-                return dark
-            case .auto:
-                return isDarkMode() ? dark : light
-            }
-            #endif
-        }
-        
         //Color
-        private static let defaultMainColor = colorType(red: 0.925, green: 0.941, blue: 0.953)
-        private static let defaultSecondaryColor = colorType(red: 0.482, green: 0.502, blue: 0.549)
-        private static let defaultLightShadowSolidColor = colorType(red: 1.000, green: 1.000, blue: 1.000)
-        private static let defaultDarkShadowSolidColor = colorType(red: 0.820, green: 0.851, blue: 0.902)
+        private static let defaultMainColor = NeumorphicKit.colorType(red: 0.925, green: 0.941, blue: 0.953)
+        private static let defaultSecondaryColor = NeumorphicKit.colorType(red: 0.482, green: 0.502, blue: 0.549)
+        private static let defaultLightShadowSolidColor = NeumorphicKit.colorType(red: 1.000, green: 1.000, blue: 1.000)
+        private static let defaultDarkShadowSolidColor = NeumorphicKit.colorType(red: 0.820, green: 0.851, blue: 0.902)
 
-        private static let darkThemeMainColor = colorType(red: 0.188, green: 0.192, blue: 0.208)
-        private static let darkThemeSecondaryColor = colorType(red: 0.910, green: 0.910, blue: 0.910)
-        private static let darkThemeLightShadowSolidColor = colorType(red: 0.243, green: 0.247, blue: 0.275)
-        private static let darkThemeDarkShadowSolidColor = colorType(red: 0.137, green: 0.137, blue: 0.137)
+        private static let darkThemeMainColor = NeumorphicKit.colorType(red: 0.188, green: 0.192, blue: 0.208)
+        private static let darkThemeSecondaryColor = NeumorphicKit.colorType(red: 0.910, green: 0.910, blue: 0.910)
+        private static let darkThemeLightShadowSolidColor = NeumorphicKit.colorType(red: 0.243, green: 0.247, blue: 0.275)
+        private static let darkThemeDarkShadowSolidColor = NeumorphicKit.colorType(red: 0.137, green: 0.137, blue: 0.137)
                 
+        public static var colorSchemeType : NeumorphicKit.ColorSchemeType {
+            get {
+                return NeumorphicKit.colorSchemeType
+            }
+            set {
+                NeumorphicKit.colorSchemeType = newValue
+            }
+        }
+        
         public static var main: Color {
-            color(light: defaultMainColor, dark: darkThemeMainColor)
+            NeumorphicKit.color(light: defaultMainColor, dark: darkThemeMainColor)
         }
         
         public static var secondary: Color {
-            color(light: defaultSecondaryColor, dark: darkThemeSecondaryColor)
+            NeumorphicKit.color(light: defaultSecondaryColor, dark: darkThemeSecondaryColor)
         }
 
         public static var lightShadow: Color {
-            color(light: defaultLightShadowSolidColor, dark: darkThemeLightShadowSolidColor)
+            NeumorphicKit.color(light: defaultLightShadowSolidColor, dark: darkThemeLightShadowSolidColor)
         }
 
         public static var darkShadow: Color {
-            color(light: defaultDarkShadowSolidColor, dark: darkThemeDarkShadowSolidColor)
+            NeumorphicKit.color(light: defaultDarkShadowSolidColor, dark: darkThemeDarkShadowSolidColor)
         }
     }
+    
+
+    
+    
 }

--- a/Sources/Neumorphic/Neumorphic.swift
+++ b/Sources/Neumorphic/Neumorphic.swift
@@ -1,8 +1,0 @@
-public enum ColorSchemeType {
-    case auto, light, dark
-}
-
-/// By Setting this variable to .light or .dark, the colorSheme can be forced.
-/// Additionally, it can be used to switch between colorSchemes manually
-/// (only recommended for OSX). Default = .auto
-public var neumorphicColorScheme = ColorSchemeType.auto

--- a/Sources/Neumorphic/Neumorphic.swift
+++ b/Sources/Neumorphic/Neumorphic.swift
@@ -1,0 +1,8 @@
+public enum ColorSchemeType {
+    case auto, light, dark
+}
+
+/// By Setting this variable to .light or .dark, the colorSheme can be forced.
+/// Additionally, it can be used to switch between colorSchemes manually
+/// (only recommended for OSX). Default = .auto
+public var neumorphicColorScheme = ColorSchemeType.auto

--- a/Sources/Neumorphic/NeumorphicKit.swift
+++ b/Sources/Neumorphic/NeumorphicKit.swift
@@ -1,0 +1,57 @@
+//
+//  Neumorphic.swift
+//  Created by Costa Chung on 2/3/2020.
+//  Copyright © 2020 Costa Chung. All rights reserved.
+//  Neumorphism Soft UI
+
+import SwiftUI
+
+public struct NeumorphicKit {
+    
+    public enum ColorSchemeType {
+        case auto, light, dark
+    }
+
+    public static var colorSchemeType : ColorSchemeType = .auto
+
+    #if os(macOS)
+    public typealias ColorType = NSColor
+    public static func colorType(red: CGFloat, green: CGFloat, blue: CGFloat) -> ColorType {
+        .init(red: red, green: green, blue: blue, alpha: 1.0)
+    }
+    #else
+    public typealias ColorType = UIColor
+    public static func colorType(red: CGFloat, green: CGFloat, blue: CGFloat) -> ColorType {
+        .init(red: red, green: green, blue: blue, alpha: 1.0)
+    }
+    #endif
+    
+    public static func color(light: ColorType, dark: ColorType) -> Color {
+        #if os(iOS)
+        switch NeumorphicKit.colorSchemeType {
+        case .light:
+            return Color(light)
+        case .dark:
+            return Color(dark)
+        case .auto:
+            return Color(.init { $0.userInterfaceStyle == .light ? light : dark })
+        }
+        #else
+        switch NeumorphicKit.colorSchemeType {
+        case .light:
+            return Color(light)
+        case .dark:
+            return Color(dark)
+        case .auto:
+            return Color(.init(name: nil, dynamicProvider: { (appearance) -> NSColor in
+                return appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua ? dark : light
+            }))
+        }
+        #endif
+    }
+
+}
+
+
+
+

--- a/neumorphic-ios-example/mac-example/ContentView.swift
+++ b/neumorphic-ios-example/mac-example/ContentView.swift
@@ -10,11 +10,9 @@ import SwiftUI
 import Neumorphic
 
 struct ContentView: View {
-
-    @Environment(\.colorScheme) var colorScheme: ColorScheme
     @State var toggleIsOn : Bool = false
     
-    var body: some View {
+    var body: some View {        
         return ZStack {
             Color.Neumorphic.main.ignoresSafeArea(.all)
             VStack() {

--- a/neumorphic-ios-example/mac-example/ContentView.swift
+++ b/neumorphic-ios-example/mac-example/ContentView.swift
@@ -10,55 +10,20 @@ import SwiftUI
 import Neumorphic
 
 struct ContentView: View {
-    @State var toggleIsOn : Bool = false
-    
-    var body: some View {        
+
+    var body: some View {
+        Color.Neumorphic.colorSchemeType = .dark
         return ZStack {
             Color.Neumorphic.main.ignoresSafeArea(.all)
             VStack() {
-                HStack(spacing: 16) {
-                    Toggle(isOn: $toggleIsOn, label: {
-                            if toggleIsOn {
-                                Image(systemName: "stop.fill")
-                                    .font(.title)
-                            }
-                            else{
-                                Image(systemName: "play.fill")
-                                    .font(.title)
-                            }
-                        })
-                        .softToggleStyle(Circle(), padding: 20)
-                    
-                    Toggle("Toggle", isOn: $toggleIsOn)
-                      .softSwitchToggleStyle(tint: .green, labelsHidden: true)
-                    
-                    Button(action: {}) {
-                        Text("Soft Button").fontWeight(.bold)
-                    }
-                    .softButtonStyle(RoundedRectangle(cornerRadius: 20))
-                }
-                .padding()
+                DemoButtonsView()
+                    .padding()
                 
-                HStack(spacing: 16) {
-                      Circle()
-                        .fill(Color.Neumorphic.main)
-                        .softOuterShadow()
-                      Circle()
-                        .fill(Color.Neumorphic.main)
-                        .softInnerShadow(Circle())
-                }
-                .padding()
+                DemoCirclesView()
+                    .padding()
                 
-                HStack(spacing: 16) {
-                    RoundedRectangle(cornerRadius: 20)
-                        .fill(Color.Neumorphic.main)
-                        .softOuterShadow()
-                    
-                    RoundedRectangle(cornerRadius: 20)
-                        .fill(Color.Neumorphic.main)
-                        .softInnerShadow(RoundedRectangle(cornerRadius: 20))
-                }
-                .padding()
+                DemoRectView()
+                    .padding()
             }
             .frame(width:500)
         }
@@ -66,12 +31,75 @@ struct ContentView: View {
     }
 }
 
+struct DemoButtonsView : View {
+
+    @State var toggleIsOn : Bool = false
+    
+    var body: some View {
+        return HStack(spacing: 16) {
+            Toggle(isOn: $toggleIsOn, label: {
+                    if toggleIsOn {
+                        Image(systemName: "stop.fill")
+                            .font(.title)
+                    }
+                    else{
+                        Image(systemName: "play.fill")
+                            .font(.title)
+                    }
+                })
+                .softToggleStyle(Circle(), padding: 20)
+            
+            Toggle("Toggle", isOn: $toggleIsOn)
+              .softSwitchToggleStyle(tint: .green, labelsHidden: true)
+            
+            Button(action: {}) {
+                Text("Soft Button").fontWeight(.bold)
+            }
+            .softButtonStyle(RoundedRectangle(cornerRadius: 20))
+        }
+    }
+    
+}
+
+struct DemoCirclesView : View {
+    
+    var body: some View {
+        return HStack(spacing: 16) {
+              Circle()
+                .fill(Color.Neumorphic.main)
+                .softOuterShadow()
+              Circle()
+                .fill(Color.Neumorphic.main)
+                .softInnerShadow(Circle())
+        }
+    }
+}
+
+struct DemoRectView : View {
+    
+    var body: some View {
+        return HStack(spacing: 16) {
+            RoundedRectangle(cornerRadius: 20)
+                .fill(Color.Neumorphic.main)
+                .softOuterShadow()
+            
+            RoundedRectangle(cornerRadius: 20)
+                .fill(Color.Neumorphic.main)
+                .softInnerShadow(RoundedRectangle(cornerRadius: 20))
+        }
+    }
+}
 
 
 struct ContentView_Previews: PreviewProvider {
+
     static var previews: some View {
-        Group {
+        return Group {
             ContentView()
+                .environment(\.colorScheme, .light)
+            ContentView()
+                .environment(\.colorScheme, .dark)
         }
     }
+    
 }

--- a/neumorphic-ios-example/neumorphic-ios-example/ContentView.swift
+++ b/neumorphic-ios-example/neumorphic-ios-example/ContentView.swift
@@ -8,10 +8,7 @@
 import SwiftUI
 import Neumorphic
 
-struct ContentView: View {
-
-    @Environment(\.colorScheme) var colorScheme: ColorScheme
-    
+struct ContentView: View {    
     var body: some View {
         let cornerRadius : CGFloat = 15
         let mainColor = Color.Neumorphic.main

--- a/neumorphic-ios-example/neumorphic-ios-example/SoftButtonDemoView.swift
+++ b/neumorphic-ios-example/neumorphic-ios-example/SoftButtonDemoView.swift
@@ -9,10 +9,7 @@
 import SwiftUI
 import Neumorphic
 
-struct SoftButtonDemoView: View {
-    
-    @Environment(\.colorScheme) var colorScheme: ColorScheme
-    
+struct SoftButtonDemoView: View {    
     var body: some View {
         return NavigationView {
             ZStack {

--- a/neumorphic-ios-example/neumorphic-ios-example/SoftSwitchToggleDemoView.swift
+++ b/neumorphic-ios-example/neumorphic-ios-example/SoftSwitchToggleDemoView.swift
@@ -18,8 +18,6 @@ extension Text {
 }
 
 struct SoftSwitchToggleDemoView: View {
-
-    @Environment(\.colorScheme) var colorScheme: ColorScheme
     @State var toggleIsOn : Bool = false
     
     var body: some View {

--- a/neumorphic-ios-example/neumorphic-ios-example/SoftToggleDemoView.swift
+++ b/neumorphic-ios-example/neumorphic-ios-example/SoftToggleDemoView.swift
@@ -9,9 +9,7 @@
 import SwiftUI
 import Neumorphic
 
-struct SoftToggleDemoView: View {
-    @Environment(\.colorScheme) var colorScheme: ColorScheme
-    
+struct SoftToggleDemoView: View {    
     @State var toggleIsOn : Bool = false
     
     var body: some View {


### PR DESCRIPTION
+ removed unused environment vars

This would allow to set the colorScheme manually as was being done before the ColorExtension update. It also can be used as a workaround for the issue with colors not updating right away on OSX (#13). 

To force a colorScheme manually you would write `neumorphicColorScheme = .light`